### PR TITLE
Fixes https://github.com/pyugrid/pyugrid/issues/24 and passes PEP8.

### DIFF
--- a/test/test_read.py
+++ b/test/test_read.py
@@ -6,6 +6,9 @@ Tests for testing a ugrid file read.
 We really need a LOT more sample data files....
 
 """
+
+import os
+import contextlib
 import pytest
 
 import numpy as np
@@ -16,89 +19,143 @@ from pyugrid import read_netcdf
 
 UGrid = ugrid.UGrid
 
+files = os.path.join(os.path.split(__file__)[0], 'files')
+file11 = 'ElevenPoints_UGRIDv0.9.nc'
+
+
+@contextlib.contextmanager
+def chdir(dirname=None):
+    curdir = os.getcwd()
+    try:
+        if dirname is not None:
+            os.chdir(dirname)
+        yield
+    finally:
+        os.chdir(curdir)
+
+
 def test_simple_read():
-    """ can it be read at all """
-    ug = UGrid.from_ncfile('files/ElevenPoints_UGRIDv0.9.nc')
+    """
+    Can it be read at all?
+    """
+
+    with chdir(files):
+        ug = UGrid.from_ncfile(file11)
 
     assert True
 
+
 def test_get_mesh_names():
     """
-    check that it can find the mesh variable
-    
+    Check that it can find the mesh variable.
+
     NOTE: this really should check for more than one mesh..
     """
-    nc = netCDF4.Dataset('files/ElevenPoints_UGRIDv0.9.nc')
-    names = read_netcdf.find_mesh_names( nc )
+
+    with chdir(files):
+        nc = netCDF4.Dataset(file11)
+    names = read_netcdf.find_mesh_names(nc)
 
     assert names == [u'Mesh2']
 
+
 def test_mesh_not_there():
+    """
+    Test raising Value error with incorrect mesh name.
+    """
+
     with pytest.raises(ValueError):
-        ug = UGrid.from_ncfile('files/ElevenPoints_UGRIDv0.9.nc', mesh_name='garbage')
+        with chdir(files):
+            ug = UGrid.from_ncfile(file11, mesh_name='garbage')
+
 
 def test_load_grid_from_nc():
     """
-    test reading a fairly full example file
+    Test reading a fairly full example file.
     """
-    grid = UGrid.from_ncfile('files/ElevenPoints_UGRIDv0.9.nc')
+
+    with chdir(files):
+        grid = UGrid.from_ncfile(file11)
 
     assert grid.mesh_name == 'Mesh2'
 
     assert grid.nodes.shape == (11, 2)
     assert grid.faces.shape == (13, 3)
-    assert grid.face_face_connectivity.shape == (13,3) 
-    assert grid.boundaries.shape == (9,2)
+    assert grid.face_face_connectivity.shape == (13, 3)
+    assert grid.boundaries.shape == (9, 2)
 
-    assert grid.edges is None # no edges in this data
+    assert grid.edges is None    # no edges in this data
+
 
 def test_read_nodes():
-	""" Do we get the right nodes array? """
-	ug = UGrid.from_ncfile('files/ElevenPoints_UGRIDv0.9.nc')
+    """
+    Do we get the right nodes array?
+    """
 
-	assert ug.nodes.shape == (11,2)
+    with chdir(files):
+        ug = UGrid.from_ncfile(file11)
 
-	# not ideal to pull specific values out, but how else to test?
-	assert np.array_equal( ug.nodes[0,:],	 (-62.242, 12.774999) )
-	assert np.array_equal( ug.nodes[-1,:],	 (-34.911235,  29.29379) )
+    assert ug.nodes.shape == (11, 2)
+
+    # not ideal to pull specific values out, but how else to test?
+    assert np.array_equal(ug.nodes[0, :],     (-62.242, 12.774999))
+    assert np.array_equal(ug.nodes[-1, :],    (-34.911235, 29.29379))
+
 
 def test_read_edges():
-    """ sample file has no edges """
-    ug = UGrid.from_ncfile('files/ElevenPoints_UGRIDv0.9.nc')
+    """
+    Do we get the right edge array?
+    """
+
+    with chdir(files):
+        ug = UGrid.from_ncfile(file11)
 
     assert ug.edges is None
 
+
 def test_read_faces():
-    """ Do we get the right faces array? """
-    ug = UGrid.from_ncfile('files/ElevenPoints_UGRIDv0.9.nc')
+    """
+    Do we get the right faces array?
+    """
+
+    with chdir(files):
+        ug = UGrid.from_ncfile(file11)
 
     assert ug.faces.shape == (13, 3)
 
     # not ideal to pull specific values out, but how else to test?
-    assert np.array_equal( ug.faces[0,:],    ( 2, 3, 10) )
-    assert np.array_equal( ug.faces[-1,:],   (10, 5,  6) )
+    assert np.array_equal(ug.faces[0, :],     (2, 3, 10))
+    assert np.array_equal(ug.faces[-1, :],    (10, 5, 6))
+
 
 def test_read_face_face():
-    """ Do we get the right face_face_connectivity array? """
-    ug = UGrid.from_ncfile('files/ElevenPoints_UGRIDv0.9.nc')
+    """
+    Do we get the right face_face_connectivity array?
+    """
+
+    with chdir(files):
+        ug = UGrid.from_ncfile(file11)
 
     assert ug.face_face_connectivity.shape == (13, 3)
 
     # not ideal to pull specific values out, but how else to test?
-    assert np.array_equal( ug.face_face_connectivity[0,:],    ( 11, 5, -1) )
-    assert np.array_equal( ug.face_face_connectivity[-1,:],   (-1, 5,  11) )
-
+    assert np.array_equal(ug.face_face_connectivity[0, :],     (11, 5, -1))
+    assert np.array_equal(ug.face_face_connectivity[-1, :],    (-1, 5, 11))
 
 
 def test_read_boundaries():
-    """ Do we get the right boundaries array? """
-    grid = UGrid.from_ncfile('files/ElevenPoints_UGRIDv0.9.nc')
+    """
+    Do we get the right boundaries array?
+    """
+
+    with chdir(files):
+        grid = UGrid.from_ncfile(file11)
 
     assert grid.boundaries.shape == (9, 2)
 
-    # # not ideal to pull specific values out, but how else to test?
-    ## note: file is 1-indexed, so these values are adjusted
-    assert np.array_equal( grid.boundaries,[[0, 1],
+    # Not ideal to pull specific values out, but how else to test?
+    # Note: file is 1-indexed, so these values are adjusted.
+    assert np.array_equal(grid.boundaries, [[0, 1],
                                             [1, 2],
                                             [2, 3],
                                             [3, 4],
@@ -106,55 +163,82 @@ def test_read_boundaries():
                                             [5, 6],
                                             [6, 7],
                                             [7, 8],
-                                            [8, 5]]
-                                            )
+                                            [8, 5],
+                                            ])
+
 
 def test_read_face_coordinates():
-    """ Do we get the right face_coordinates array? """
-    grid = UGrid.from_ncfile('files/ElevenPoints_UGRIDv0.9.nc')
+    """
+    Do we get the right face_coordinates array?
+    """
+
+    with chdir(files):
+        grid = UGrid.from_ncfile(file11)
 
     assert grid.face_coordinates.shape == (13, 2)
 
-    # # not ideal to pull specific values out, but how else to test?
-    assert np.array_equal( grid.face_coordinates[0], (-37.1904106666667, 30.57093) )
-    assert np.array_equal( grid.face_coordinates[-1], (-38.684412, 27.7132626666667) )
+    # Not ideal to pull specific values out, but how else to test?
+    assert np.array_equal(grid.face_coordinates[0],
+                          (-37.1904106666667, 30.57093))
+    assert np.array_equal(grid.face_coordinates[-1],
+                          (-38.684412, 27.7132626666667))
+
 
 def test_read_edge_coordinates():
-    grid = UGrid.from_ncfile('files/ElevenPoints_UGRIDv0.9.nc')
+    """
+    Do we get the right edge_coordinates array?
+    """
+
+    with chdir(files):
+        grid = UGrid.from_ncfile(file11)
 
     # not in this sample file
     assert grid.edge_coordinates is None
 
+
 def test_read_boundary_coordinates():
-    """ Do we get the right boundary_coordinates array? """
-    grid = UGrid.from_ncfile('files/ElevenPoints_UGRIDv0.9.nc')
+    """
+    Do we get the right boundary_coordinates array?
+    """
+
+    with chdir(files):
+        grid = UGrid.from_ncfile(file11)
 
     # not in this sample file
     assert grid.boundary_coordinates is None
 
+
 def test_read_data1():
-    """ sample file has depths on the nodes -- that should get read in """
+    """
+    Sample file has depths on the nodes -- the key should get read in.
+    """
 
-    grid = UGrid.from_ncfile('files/ElevenPoints_UGRIDv0.9.nc')
+    with chdir(files):
+        grid = UGrid.from_ncfile(file11)
 
-    assert sorted(grid.data.keys()) == [u'boundary_count', u'boundary_types', u'depth']
+    assert sorted(grid.data.keys()) == [u'boundary_count',
+                                        u'boundary_types',
+                                        u'depth']
+
 
 def test_read_data2():
-    """ sample file has depths on the nodes -- that should get read in """
+    """
+    Sample file has depths on the nodes -- the data should get read in.
+    """
 
-    grid = UGrid.from_ncfile('files/ElevenPoints_UGRIDv0.9.nc')
+    with chdir(files):
+        grid = UGrid.from_ncfile(file11)
 
-    assert grid.data['depth'] is not None
-    assert np.array_equal( grid.data['depth'].data, [1, 1, 1, 102, 1, 1, 60, 1, 1, 97, 1] )
-    assert grid.data['depth'].attributes == { 'standard_name' : "sea_floor_depth_below_geoid",
-                                              'units' : "m",
-                                              'positive' : "down",
-                                              'mesh' : "Mesh2",
-                                              }
-
+    # assert grid.data['depth'] is not None
+    depth_data11 = [1, 1, 1, 102, 1, 1, 60, 1, 1, 97, 1]
+    assert np.array_equal(grid.data['depth'].data, depth_data11)
+    depth_attributes11 = {'standard_name': "sea_floor_depth_below_geoid",
+                          'units': "m",
+                          'positive': "down",
+                          'mesh': "Mesh2",
+                          }
+    assert grid.data['depth'].attributes == depth_attributes11
 
 
 if __name__ == "__main__":
     test_simple_read()
-
- 


### PR DESCRIPTION
Adds a context manager to switch tests into the proper directory for loading test files. Bonus: fixed some spacing that had used tabs and PEP8-afied test_read.py.
