### PR TITLE
Fixes https://github.com/pyugrid/pyugrid/issues/21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+python:
+  - "2.7"
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y python-dev
+  - sudo apt-get install -y libhdf5-serial-dev
+  - sudo apt-get install -y libnetcdf-dev
+install: 
+  - "pip install cython"
+  - "pip install numpy"
+  - "pip install netCDF4"
+script: "py.test"
+notifications:
+  irc: "chat.freenode.net#renci"
+


### PR DESCRIPTION
Travis uses Ubuntu 12.04 LTS. So I tested on such an instance using a Vagrant box and found the dependencies for a Travis build. I then constructed the .travis.yml in a branch and ran the validator at http://lint.travis-ci.org/ and passed. When I pushed the commit in this PR to the branch, the addition of the .travis.yml file triggered a Travis build which passed in 4 min 46 secs on an apparently slow guest box. You can see the results at: https://travis-ci.org/pyugrid/pyugrid . I did get a default automated email notification, but did not see a notification on IRC.
