### PR TITLE
added global attribute Conventions='UGRID-0.9' when saving pyugrid as netcdf file

### DIFF
--- a/pyugrid/ugrid.py
+++ b/pyugrid/ugrid.py
@@ -473,7 +473,7 @@ class UGrid(object):
         self.boundary_coordinates = boundary_coordinates
 
 
-    def save_as_netcdf(self, filepath, conventions="CF-{0}, UGRID-{1}".format(cf_version, ug_version)):
+    def save_as_netcdf(self, filepath):
         """
         save the ugrid object as a netcdf file
 
@@ -492,7 +492,7 @@ class UGrid(object):
         from netCDF4 import num2date, date2num
         # create a new netcdf file
         with ncDataset(filepath, mode="w", clobber=True) as nclocal:
-            nclocal.Conventions = conventions
+            nclocal.Conventions="CF-{0}, UGRID-{1}".format(UGrid.cf_version, UGrid.ug_version)
             nclocal.createDimension(mesh_name+'_num_node', len(self.nodes) )
             if self._edges is not None:
                 nclocal.createDimension(mesh_name+'_num_edge', len(self.edges) )

--- a/pyugrid/ugrid.py
+++ b/pyugrid/ugrid.py
@@ -491,7 +491,7 @@ class UGrid(object):
         from netCDF4 import num2date, date2num
         # create a new netcdf file
         with ncDataset(filepath, mode="w", clobber=True) as nclocal:
-
+            nclocal.Conventions = 'UGRID-0.9'
             nclocal.createDimension(mesh_name+'_num_node', len(self.nodes) )
             if self._edges is not None:
                 nclocal.createDimension(mesh_name+'_num_edge', len(self.edges) )

--- a/pyugrid/ugrid.py
+++ b/pyugrid/ugrid.py
@@ -35,7 +35,8 @@ class UGrid(object):
 
     the internal structure mirrors the netcdf data standard.
     """
-
+    ug_version='0.9'
+    cf_version='1.6'
     def __init__(self,
                  nodes=None,
                  faces=None,
@@ -472,7 +473,7 @@ class UGrid(object):
         self.boundary_coordinates = boundary_coordinates
 
 
-    def save_as_netcdf(self, filepath):
+    def save_as_netcdf(self, filepath, conventions="CF-{0}, UGRID-{1}".format(cf_version, ug_version)):
         """
         save the ugrid object as a netcdf file
 
@@ -491,7 +492,7 @@ class UGrid(object):
         from netCDF4 import num2date, date2num
         # create a new netcdf file
         with ncDataset(filepath, mode="w", clobber=True) as nclocal:
-            nclocal.Conventions = 'UGRID-0.9'
+            nclocal.Conventions = conventions
             nclocal.createDimension(mesh_name+'_num_node', len(self.nodes) )
             if self._edges is not None:
                 nclocal.createDimension(mesh_name+'_num_edge', len(self.edges) )


### PR DESCRIPTION
pyugrid has the ability to save topologies as a netcdf files using pyugrid.UGrid.save_as_netcdf but this function was not saving the global attribute `Convention = 'UGRID-0.9'` guaranteed by the [netcdf ugrid standard](https://github.com/ugrid-conventions/ugrid-conventions).

This modification adds the the `Conventions` global attribute as a hard coded string in the save_as_netcdf function. A more proper approach would be to make a netcdf version string globally available which would be referenced within the save_as_netcdf function and a secondary purpose of this pull request is to begin a discussion about where this version string should be stored (if said variable is deemed appropriate by the community). I think it should be a static variable on the pyugrid.UGrid class or in the top level \__init\__.py, i.e., ugrid_netcdf_version='0.9' which could change as pyugrid is adopted to future versions of the ugrid standard.

My use case for this change is for incorporating pyugrid in sci-wms to achieve ugrid conformance and improve modularity asascience-open/sci-wms#120. sci-wms caches grid topologies as netcdf files and it would be most convenient to open all cache topologies using netcdf then determine if the topology is a ugrid by checking the `Conventions` attribute and proceed to build the topology using pyugrid.UGrid.from_nc_dataset if appropriate.

@rsignell-usgs Please review at your convenience. 

@brianmckenna @daf @kknee