### PR TITLE
MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include *.rst
+include *.txt
+recursive-include pyugrid *.py


### PR DESCRIPTION
Without a `MANIFEST.in` the tarball generate with `python setup.py sdist` is missing a few files.  Like the `VERSION.txt`.

Note that I did not add the directories `docs/`, `scripts/`, `test_bed/` and `test_data/` to the source tarball.   Let me know if you think we should ship them as well.