### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
     - CONDA="python=2.7"
     - CONDA="python=3.3"
     - CONDA="python=3.4"
+    - CONDA="python=3.5"
 
 before_install:
     - wget http://bit.ly/miniconda -O miniconda.sh

--- a/pyugrid/read_netcdf.py
+++ b/pyugrid/read_netcdf.py
@@ -203,7 +203,7 @@ def load_grid_from_nc_dataset(nc, grid, mesh_name=None, load_data=True):
             if array.shape[0] == defs['num_ind']:
                 array = array.T
             try:
-                start_index = var.start_index
+                start_index = int(var.start_index)
             except AttributeError:
                 start_index = 0
             if start_index >= 1:


### PR DESCRIPTION
Safe casting to the same `dtype`.  This avoids the failure we are seeing [here](https://travis-ci.org/pyugrid/pyugrid/jobs/86395763#L464).