### PR TITLE
No mkl download

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ before_install:
     - wget http://bit.ly/miniconda -O miniconda.sh
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"
-    - conda update --all --yes
-    - travis_retry conda create --yes -n TEST python=$TRAVIS_PYTHON_VERSION --file requirements.txt
+    - travis_retry conda create --yes -n TEST python=$TRAVIS_PYTHON_VERSION nomkl --file requirements.txt
     - source activate TEST
     - travis_retry pip install -r requirements-dev.txt
 


### PR DESCRIPTION
The `mkl` library is ~120MB. That is an unnecessary download for this project. Travis-CI will finishes faster without it.