### PR TITLE
removal of mesh name from variable name

### DIFF
--- a/pyugrid/read_netcdf.py
+++ b/pyugrid/read_netcdf.py
@@ -253,7 +253,8 @@ def load_grid_from_nc_dataset(nc, grid, mesh_name=None, load_data=True):
                           if n not in ('location', 'coordinates', 'mesh')}
 
             # Trick with the name: FIXME: Is this a good idea?
-            name = name.lstrip(mesh_name).lstrip('_')
+            if name.startswith(mesh_name+"_"):
+              name = name[len(mesh_name):]
             uvar = UVar(name, data=var[:],
                         location=location, attributes=attributes)
             grid.add_data(uvar)

--- a/pyugrid/read_netcdf.py
+++ b/pyugrid/read_netcdf.py
@@ -254,7 +254,7 @@ def load_grid_from_nc_dataset(nc, grid, mesh_name=None, load_data=True):
 
             # Trick with the name: FIXME: Is this a good idea?
             if name.startswith(mesh_name+"_"):
-              name = name[len(mesh_name):]
+                name = name[len(mesh_name)+1:]
             uvar = UVar(name, data=var[:],
                         location=location, attributes=attributes)
             grid.add_data(uvar)


### PR DESCRIPTION
When a variable is loaded using pyugrid, the mesh name together with a underline "_" is removed from the variable name if present. That means a variable "Mesh2_velocity" on the mesh "Mesh2" is translated to "velocity". However, the UGRID convention does not prescribe to have the mesh name at the beginning of the variable name as far as I know. So the variable name could also be "velocity" in this case in the NetCDF file.

The removal in pyugrid is done using the lstrip routine. This leads to problems, since lstrip does not remove a string, it removes all characters within this string, no matter of the order. So if there is  for example a variable "ssh" on the mesh "Mesh2", then the variable has an empty name in the worst case. The given fix just removes the mesh name and a following underscore.